### PR TITLE
Modify task names, allowing multiple instances

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -230,7 +230,7 @@
   when: plone_use_supervisor
   template:
     src=supervisor_task.j2
-    dest={{ supervisor_config_dir }}/{{ plone_instance_name }}-zeo.conf
+    dest={{ supervisor_config_dir }}/{{ plone_instance_name }}-zeocluster.conf
     owner=root
     group=root
     mode=644

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -230,7 +230,7 @@
   when: plone_use_supervisor
   template:
     src=supervisor_task.j2
-    dest={{ supervisor_config_dir }}/zeo.conf
+    dest={{ supervisor_config_dir }}/{{ plone_instance_name }}-zeo.conf
     owner=root
     group=root
     mode=644
@@ -243,20 +243,20 @@
 - name: Supervisor zeoserver task is present
   when: plone_use_supervisor
   supervisorctl:
-    name=zeoserver
+    name={{ plone_instance_name }}-zeoserver
     state=present
 
 - name: Supervisor zeoclient tasks are present
   when: plone_use_supervisor
   supervisorctl:
-    name=zeoclient{{ item }}
+    name={{ plone_instance_name }}-zeoclient{{ item }}
     state=present
   with_sequence: count={{ plone_client_count }}
 
 - name: Supervisor zeoclients tasks are restarted
   when: plone_use_supervisor and plone_autorun_buildout and instance_status.changed
   supervisorctl:
-    name=zeoclient{{ item }}
+    name={{ plone_instance_name }}-zeoclient{{ item }}
     state=restarted
   with_sequence: count={{ plone_client_count }}
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -303,7 +303,7 @@
 - name: Pack cron job
   when: plone_pack_at
   cron:
-    name="Plone packing"
+    name="Plone packing - {{ plone_instance_name }}"
     job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/zeopack"
     user=plone_daemon
     minute={{ plone_pack_at["minute"] }}
@@ -313,7 +313,7 @@
 - name: Backup cron job
   when: plone_backup_at
   cron:
-    name="Plone backup"
+    name="Plone backup - {{ plone_instance_name }}"
     job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/backup"
     user=plone_daemon
     minute={{ plone_backup_at["minute"] }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -246,6 +246,12 @@
     name={{ plone_instance_name }}-zeoserver
     state=present
 
+- name: Supervisor zeoserver process is started
+  when: plone_use_supervisor and plone_autorun_buildout and instance_status.changed
+  supervisorctl:
+    name={{ plone_instance_name }}-zeoserver
+    state=started
+
 - name: Supervisor zeoclient tasks are present
   when: plone_use_supervisor
   supervisorctl:

--- a/templates/restart_clients.sh.j2
+++ b/templates/restart_clients.sh.j2
@@ -11,9 +11,9 @@
 
 for client in {% for client in range(1, plone_client_count+1) %}{{ client }} {% endfor %}; do
     echo Restarting client $client
-    supervisorctl stop zeoclient${client}
+    supervisorctl stop {{ plone_instance_name }}-zeoclient${client}
     sleep 40
-    supervisorctl start zeoclient${client}
+    supervisorctl start {{ plone_instance_name }}-zeoclient${client}
     sleep 10
 
 {% if webserver_virtualhosts is defined %}

--- a/templates/supervisor_task.j2
+++ b/templates/supervisor_task.j2
@@ -1,4 +1,4 @@
-[program:zeoserver]
+[program:{{ plone_instance_name }}-zeoserver]
 command={{ plone_target_path }}/{{ plone_instance_name }}/bin/zeoserver fg
 directory={{ plone_target_path }}/{{ plone_instance_name }}
 redirect_stderr={{ plone_redirect_stderr }}
@@ -12,7 +12,7 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 {% endif %}
 
 {% for client in range(1, plone_client_count+1) %}
-[program:zeoclient{{ client }}]
+[program:{{ plone_instance_name }}-zeoclient{{ client }}]
 command={{ plone_target_path }}/{{ plone_instance_name }}/bin/client{{ client }} console
 directory={{ plone_target_path }}/{{ plone_instance_name }}
 redirect_stderr={{ plone_redirect_stderr }}
@@ -29,6 +29,6 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 
 {% if plone_client_max_memory != 0 %}
 [eventlistener:memmon]
-command=memmon -a {{ plone_client_max_memory }} -c -m root
+command=memmon{% for client in range(1, plone_client_count+1) %} -p {{ plone_instance_name }}-zeoclient{{ client }}={{ plone_client_max_memory }}{% endfor %} -c -m root
 events=TICK_60
 {% endif %}

--- a/templates/supervisor_task.j2
+++ b/templates/supervisor_task.j2
@@ -28,7 +28,7 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 {% endfor %}
 
 {% if plone_client_max_memory != 0 %}
-[eventlistener:memmon]
+[eventlistener:{{ plone_instance_name }}-memmon]
 command=memmon{% for client in range(1, plone_client_count+1) %} -p {{ plone_instance_name }}-zeoclient{{ client }}={{ plone_client_max_memory }}{% endfor %} -c -m root
 events=TICK_60
 {% endif %}


### PR DESCRIPTION
To better support running multiple Plone servers on a single machine, in the case of eg having a few staging instances on one server.

cbb: no supervisor groups created, just used -p repeatedly in the memmon line.