### PR TITLE
update client port variable replacements

### DIFF
--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -152,13 +152,13 @@ http-address = 127.0.0.1:{{ plone_client_base_port }}
 [client{{ client }}]
 <= client_base
 recipe = plone.recipe.zope2instance
-http-address = 127.0.0.1:{{ plone_client_base_port + client}}
+http-address = 127.0.0.1:{{ "%s" % (plone_client_base_port|int + loop.index) }}
 {% endfor %}
 
 [client_reserved]
 <= client_base
 recipe = plone.recipe.zope2instance
-http-address = 127.0.0.1:{{ plone_client_base_port + plone_client_count }}
+http-address = 127.0.0.1:{{ "%s" % (plone_client_base_port|int + plone_client_count) }}
 
 
 [backup]


### PR DESCRIPTION
In my local vars.yml file I am setting the client-port ranges slightly differently.  I'm not sure why, but I receive "cannot coerce int to unicode" errors when I run the playbook.  This commit should work the same as the default, but it makes these errors go away.