### PR TITLE
Disambiguate cron and supervisor configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,12 @@ The full local (host) filepath of a buildout egg cache. Defaults to none. Should
 
 ### Cron jobs
 
+#### plone_cron_prefix
+
+    plone_cron_prefix: prefix
+
+If you want to create multiple Plone instances on one server, then multiple cron jobs will probably need to be created.  Ansible uses the provided prefix to manage these.
+
 #### plone_pack_at
 
     plone_pack_at:
@@ -301,6 +307,13 @@ Where do you want to put your backups? The destination must be writable by the `
 
 When set to `yes` (the default), the role will set up [supervisor](http://supervisord.org/) to start, stop and control the ZEO server and all the clients except the reserved client.
 
+#### supervisor_instance_name
+
+    supervisor_instance_name: name
+
+    When creating multiple Plone instances, multiple supervisor configurations are required.  This value is used as a prefix for the supervisor configuration filename, and for the programs defined inside that file.
+
+    If this value is not specified, the configuration file is named 'zeo.conf', and the programs are called 'zeoserver' and 'zeoclient<x>'.
 
 Example Playbook
 ----------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,6 +52,8 @@ plone_buildout_cache_file:
 
 plone_sources:
 
+plone_cron_prefix:
+
 plone_pack_at:
   minute: 30
   hour: 1
@@ -79,6 +81,8 @@ plone_extension_profiles:
 # Supervisor options
 #
 plone_use_supervisor: yes
+
+supervisor_instance_name:
 
 supervisor_config_dir: "/etc/supervisor/conf.d/"
 plone_redirect_stderr: "false"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -305,7 +305,7 @@
 ###################################
 # cron jobs
 
-- name: "{{ plone_cron_prefix + ' ' or ''}}Pack cron job"
+- name: "Pack cron job"
   when: plone_pack_at
   cron:
     name="{{ plone_cron_prefix + ' ' or ''}} Plone packing"
@@ -315,7 +315,7 @@
     hour={{ plone_pack_at.hour }}
     weekday={{ plone_pack_at.weekday }}
 
-- name: "{{ plone_cron_prefix + ' ' or ''}}Backup cron job"
+- name: "Backup cron job"
   when: plone_backup_at
   cron:
     name="{{ plone_cron_prefix + ' ' or ''}}Plone backup"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,7 +5,6 @@
     msg: "You must set the plone_initial_password variable."
   when: not plone_initial_password
 
-
 ###################################
 # Prerequisites
 
@@ -242,7 +241,7 @@
   when: plone_use_supervisor
   template:
     src=supervisor_task.j2
-    dest={{ supervisor_config_dir }}/zeo.conf
+    dest={{ supervisor_config_dir }}/{{ supervisor_instance_name or ''}}zeo.conf
     owner=root
     group=root
     mode=644
@@ -255,20 +254,20 @@
 - name: Supervisor zeoserver task is present
   when: plone_use_supervisor
   supervisorctl:
-    name=zeoserver
+    name={{ supervisor_instance_name or ''}}zeoserver
     state=present
 
 - name: Supervisor zeoclient tasks are present
   when: plone_use_supervisor
   supervisorctl:
-    name=zeoclient{{ item }}
+    name={{ supervisor_instance_name or '' }}zeoclient{{ item }}
     state=present
   with_sequence: count={{ plone_client_count }}
 
 - name: Supervisor zeoclients tasks are restarted
   when: plone_use_supervisor and plone_autorun_buildout and instance_status.changed
   supervisorctl:
-    name=zeoclient{{ item }}
+    name={{ supervisor_instance_name or ''}}zeoclient{{ item }}
     state=restarted
   with_sequence: count={{ plone_client_count }}
 
@@ -306,22 +305,23 @@
 ###################################
 # cron jobs
 
-- name: Pack cron job
+- name: "{{ plone_cron_prefix + ' ' or ''}}Pack cron job"
   when: plone_pack_at
   cron:
-    name="Plone packing"
+    name="{{ plone_cron_prefix + ' ' or ''}} Plone packing"
     job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/zeopack"
     user=plone_daemon
     minute={{ plone_pack_at["minute"] }}
     hour={{ plone_pack_at.hour }}
     weekday={{ plone_pack_at.weekday }}
 
-- name: Backup cron job
+- name: "{{ plone_cron_prefix + ' ' or ''}}Backup cron job"
   when: plone_backup_at
   cron:
-    name="Plone backup"
+    name="{{ plone_cron_prefix + ' ' or ''}}Plone backup"
     job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/backup"
     user=plone_daemon
     minute={{ plone_backup_at["minute"] }}
     hour={{ plone_backup_at.hour }}
     weekday={{ plone_backup_at.weekday }}
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -308,7 +308,7 @@
 - name: "Pack cron job"
   when: plone_pack_at
   cron:
-    name="{{ plone_cron_prefix + ' ' or ''}} Plone packing"
+    name="{{ plone_cron_prefix + ' ' or ''}}Plone packing"
     job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/zeopack"
     user=plone_daemon
     minute={{ plone_pack_at["minute"] }}

--- a/templates/addPloneSite.py.j2
+++ b/templates/addPloneSite.py.j2
@@ -22,7 +22,7 @@ default_extension_profiles = (
 
 if site_id in app.objectIds():
     print "A Plone site already exists"
-    sys.exit(1)
+    sys.exit(0)
 
 addPloneSite(
     app, site_id,

--- a/templates/restart_clients.sh.j2
+++ b/templates/restart_clients.sh.j2
@@ -11,9 +11,9 @@
 
 for client in {% for client in range(1, plone_client_count+1) %}{{ client }} {% endfor %}; do
     echo Restarting client $client
-    supervisorctl stop zeoclient${client}
+    supervisorctl stop {{ supervisor_instance_name or '' }}zeoclient${client}
     sleep 40
-    supervisorctl start zeoclient${client}
+    supervisorctl start {{ supervisor_instance_name or '' }}zeoclient${client}
     sleep 10
 
 {% if webserver_virtualhosts is defined %}

--- a/templates/supervisor_task.j2
+++ b/templates/supervisor_task.j2
@@ -1,4 +1,4 @@
-[program:zeoserver]
+[program:{{ supervisor_instance_name or '' }}zeoserver]
 command={{ plone_target_path }}/{{ plone_instance_name }}/bin/zeoserver fg
 directory={{ plone_target_path }}/{{ plone_instance_name }}
 redirect_stderr={{ plone_redirect_stderr }}
@@ -12,7 +12,7 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 {% endif %}
 
 {% for client in range(1, plone_client_count+1) %}
-[program:zeoclient{{ client }}]
+[program:{{ supervisor_instance_name or '' }}zeoclient{{ client }}]
 command={{ plone_target_path }}/{{ plone_instance_name }}/bin/client{{ client }} console
 directory={{ plone_target_path }}/{{ plone_instance_name }}
 redirect_stderr={{ plone_redirect_stderr }}
@@ -29,6 +29,6 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 
 {% if plone_client_max_memory != 0 %}
 [eventlistener:memmon]
-command=memmon -a {{ plone_client_max_memory }} -c -m root
+command=memmon{% for client in range(1, plone_client_count+1) %} -p {{ supervisor_instance_name or '' }}zeoclient{{ client }}={{ plone_client_max_memory }}{% endfor %} -c -m root
 events=TICK_60
 {% endif %}

--- a/templates/supervisor_task.j2
+++ b/templates/supervisor_task.j2
@@ -28,7 +28,7 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 {% endfor %}
 
 {% if plone_client_max_memory != 0 %}
-[eventlistener:memmon]
+[eventlistener:{{ supervisor_instance_name or '' }}memmon]
 command=memmon{% for client in range(1, plone_client_count+1) %} -p {{ supervisor_instance_name or '' }}zeoclient{{ client }}={{ plone_client_max_memory }}{% endfor %} -c -m root
 events=TICK_60
 {% endif %}


### PR DESCRIPTION
- plone_cron_prefix, used to distinguish cron jobs
- supervisor_instance_name, used for supervisor config filename and program names.

This is backward compatible, so there's no "-" between supervisor_instance_name and "zeo.conf".  I could add it in three extra chars, but this looks simpler to read.