### PR TITLE
Introduce variable `plone_instance_home` and siblings.    

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -12,6 +12,9 @@
 - Add ability to set extension profiles for site creation.
   [rockfruit]
 
+- Introduce variables `plone_instance_home`, `plone_instance_var_path`
+  and `plone_instance_backup_path`. [htgoebel]
+
 - Fix some bugs occuring in uncommon environments. [htgoebel]
 
 1.0b7 2015-01-27

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -12,6 +12,8 @@
 - Add ability to set extension profiles for site creation.
   [rockfruit]
 
+- Fix some bugs occuring in uncommon environments. [htgoebel]
+
 1.0b7 2015-01-27
 
 - There is a zope package that has some files that are not world-readable.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,10 @@ plone_var_path: /var/local/plone-{{ plone_major_version }}
 
 plone_instance_name: zeoserver
 
+plone_instance_home: '{{ plone_target_path }}/{{ plone_instance_name }}'
+plone_instance_var_path: '{{ plone_var_path }}/{{ plone_instance_name }}'
+plone_instance_backup_path: '{{ plone_backup_path }}/{{ plone_instance_name }}'
+
 plone_buildout_git_repo: no
 
 plone_buildout_git_version: master

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -148,7 +148,7 @@
 
 - name: Instance directory
   file:
-    path={{ plone_target_path }}/{{ plone_instance_name }}
+    path={{ plone_instance_home }}
     state=directory
     owner=plone_buildout
     group=plone_group
@@ -157,7 +157,7 @@
   when: not plone_buildout_git_repo
   copy:
     src=zeocluster/
-    dest={{ plone_target_path }}/{{ plone_instance_name }}
+    dest={{ plone_instance_home }}
     owner=plone_buildout
     group=plone_group
 
@@ -166,7 +166,7 @@
   git:
     repo={{ plone_buildout_git_repo }}
     force=no
-    dest={{ plone_target_path }}/{{ plone_instance_name }}
+    dest={{ plone_instance_home }}
     version={{ plone_buildout_git_version | default('HEAD') }}
     depth=1
     accept_hostkey=yes
@@ -174,7 +174,7 @@
 
 - name: Instance var directory
   file:
-    path={{ plone_var_path }}/{{ plone_instance_name }}
+    path={{ plone_instance_var_path }}
     state=directory
     owner=plone_daemon
     group=plone_group
@@ -183,7 +183,7 @@
 - name: Instance backup directory
   when: plone_backup_path
   file:
-    path={{ plone_backup_path }}/{{ plone_instance_name }}
+    path={{ plone_instance_backup_path }}
     state=directory
     owner=plone_daemon
     group=plone_group
@@ -200,14 +200,14 @@
   when: not plone_buildout_git_repo
   template:
     src=buildout.cfg.j2
-    dest={{ plone_target_path }}/{{ plone_instance_name }}/buildout.cfg
+    dest={{ plone_instance_home }}/buildout.cfg
     owner=plone_buildout
     group=plone_group
     backup=yes
   register: instance_status
   
 - name: Check that buildout ran successfully
-  stat: path={{ plone_target_path }}/{{ plone_instance_name }}/bin/client_reserved
+  stat: path={{ plone_instance_home }}/bin/client_reserved
   register: buildout_status
 
 
@@ -216,14 +216,14 @@
 
 - name: Bootstrap buildout
   command: ../Python-{{ plone_python_version }}/bin/python bootstrap.py --setuptools-version=8.0.4
-    creates={{ plone_target_path }}/{{ plone_instance_name }}/bin/buildout
-    chdir={{ plone_target_path }}/{{ plone_instance_name }}
+    creates={{ plone_instance_home }}/bin/buildout
+    chdir={{ plone_instance_home }}
   sudo_user: plone_buildout
 
 - name: Run buildout
   when: plone_autorun_buildout and (instance_status.changed or buildout_status.stat.exists == False)
   command: bin/buildout
-    chdir={{ plone_target_path }}/{{ plone_instance_name }}
+    chdir={{ plone_instance_home }}
   sudo_user: plone_buildout
 
 - name: Everything in buildout cache is group-readable
@@ -231,7 +231,7 @@
 
 - name: Look for existing database
   when: plone_create_site
-  stat: path={{ plone_var_path }}/{{ plone_instance_name }}/filestorage/Data.fs
+  stat: path={{ plone_instance_var_path }}/filestorage/Data.fs
   register: db_status
 
 
@@ -279,13 +279,13 @@
 
 - name: Ensure scripts directory
   file:
-    path={{ plone_target_path }}/{{ plone_instance_name }}/scripts
+    path={{ plone_instance_home }}/scripts
     state=directory
 
 - name: Create restart script
   template:
     src=restart_clients.sh.j2
-    dest={{ plone_target_path }}/{{ plone_instance_name }}/scripts/restart_clients.sh
+    dest={{ plone_instance_home }}/scripts/restart_clients.sh
     owner=root
     group=root
     mode=0755
@@ -297,7 +297,7 @@
 - name: Install site creation run script
   template:
     src=addPloneSite.py.j2
-    dest={{ plone_target_path }}/{{ plone_instance_name }}/bin/addPloneSite.py
+    dest={{ plone_instance_home }}/bin/addPloneSite.py
     mode=0444
 
 - name: Create initial Plone site
@@ -305,7 +305,7 @@
   sudo_user: plone_daemon
   command: bin/client_reserved run bin/addPloneSite.py
   args:
-    chdir: "{{ plone_target_path }}/{{ plone_instance_name }}"
+    chdir: "{{ plone_instance_home }}"
 
 
 ###################################
@@ -315,7 +315,7 @@
   when: plone_pack_at
   cron:
     name="Plone packing"
-    job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/zeopack"
+    job="cd {{ plone_instance_home }} && bin/zeopack"
     user=plone_daemon
     minute={{ plone_pack_at["minute"] }}
     hour={{ plone_pack_at.hour }}
@@ -325,7 +325,7 @@
   when: plone_backup_at
   cron:
     name="Plone backup"
-    job="cd {{ plone_target_path }}/{{ plone_instance_name }} && bin/backup"
+    job="cd {{ plone_instance_home }} && bin/backup"
     user=plone_daemon
     minute={{ plone_backup_at["minute"] }}
     hour={{ plone_backup_at.hour }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -255,7 +255,7 @@
 
 - name: Supervisor task list is updated
   when: plone_use_supervisor and supervisor_task_conf|changed
-  shell: "supervisorctl update"
+  command: supervisorctl update
 
 - name: Supervisor zeoserver task is present
   when: plone_use_supervisor

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,7 @@
   apt: pkg={{ item }} state=present
   with_items:
     - build-essential
+    - cron
     - python-dev
     - python-pip
     - libz-dev

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -248,6 +248,10 @@
     mode=644
   register: supervisor_task_conf
 
+- name: Ensure supervisord is running
+  when: plone_use_supervisor
+  service: name=supervisor state=running
+
 - name: Supervisor task list is updated
   when: plone_use_supervisor and supervisor_task_conf|changed
   shell: "supervisorctl update"

--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -48,10 +48,10 @@ zcml =
 {% endfor %}
 {% endif %}
 
-var-dir={{ plone_var_path }}/{{ plone_instance_name }}
+var-dir={{ plone_instance_var_path }}
 
 {% if plone_backup_path %}
-backups-dir={{ plone_backup_path }}/{{ plone_instance_name }}
+backups-dir={{ plone_instance_backup_path }}
 {% else %}
 backups-dir=${buildout:var-dir}
 {% endif %}

--- a/templates/supervisor_task.j2
+++ b/templates/supervisor_task.j2
@@ -1,6 +1,6 @@
 [program:zeoserver]
-command={{ plone_target_path }}/{{ plone_instance_name }}/bin/zeoserver fg
-directory={{ plone_target_path }}/{{ plone_instance_name }}
+command={{ plone_instance_home }}/bin/zeoserver fg
+directory={{ plone_instance_home }}
 redirect_stderr={{ plone_redirect_stderr }}
 autostart={{ plone_autostart }}
 autorestart={{ plone_autorestart }}
@@ -13,8 +13,8 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 
 {% for client in range(1, plone_client_count+1) %}
 [program:zeoclient{{ client }}]
-command={{ plone_target_path }}/{{ plone_instance_name }}/bin/client{{ client }} console
-directory={{ plone_target_path }}/{{ plone_instance_name }}
+command={{ plone_instance_home }}/bin/client{{ client }} console
+directory={{ plone_instance_home }}
 redirect_stderr={{ plone_redirect_stderr }}
 autostart={{ plone_autostart }}
 autorestart={{ plone_autorestart }}


### PR DESCRIPTION
This variable replaces the use of `'{{ plone_target_path }}/{{ plone_instance_name }}'` (which still is the default value). This allows for easy changing the server-layout if one does not want the instance-home to be below target-path.

For symmetry also introduce `plone_instance_var_path` and    `plone_instance_backup_path`.
