### PR TITLE
Fixes issue #31, ensure string to boolean casting.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -155,7 +155,7 @@
     group=plone_group
 
 - name: Copy buildout skeleton
-  when: not plone_buildout_git_repo
+  when: not (plone_buildout_git_repo)
   copy:
     src=zeocluster/
     dest={{ plone_instance_home }}
@@ -163,7 +163,7 @@
     group=plone_group
 
 - name: Instance directory via git
-  when: plone_buildout_git_repo
+  when: (plone_buildout_git_repo)
   git:
     repo={{ plone_buildout_git_repo }}
     force=no


### PR DESCRIPTION
this way seems to be the better way to cast the string to boolean for the when expression, I tested and works well with this values:
plone_buildout_git_repo: no
plone_buildout_git_repo: git@github.com:myrepo.git
plone_buildout_git_repo: "git@github.com:myrepo.git"
