### PR TITLE
make it possible to run an alternate buildout configuration file

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Your install's backup directory will be {{ plone_backup_path }}/{{ plone_instanc
 
 `buildout_git_version` is the tag or branch. Defaults to `master`.
 
+`buildout_git_file` is the buildout configuration file to run. Defaults to `buildout.cfg`.
+
 > If you use your own buildout from a repository, you still need to specify your client count so that the playbook can 1) set up the supervisor specifications to start/stop and monitor clients, and 2) set up the load balancer.
 >
 > Client part names must follow the pattern `client#` where # is a number (1,2,3 ...). Client ports must be numbered sequentially beginning with 8081 or the value you set for plone_client_base_port. The zeoserver part must be named `zeoserver` and be at 8100 or the value you set for plone_zeo_port.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,8 @@ plone_buildout_git_repo: no
 
 plone_buildout_git_version: master
 
+plone_buildout_file: buildout.cfg
+
 plone_initial_password:
 
 plone_client_count: 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -272,14 +272,14 @@
 # Bootstrap and run buildout
 
 - name: Bootstrap buildout
-  command: ../Python-{{ plone_python_version }}/bin/python bootstrap.py --setuptools-version=8.0.4
+  command: ../Python-{{ plone_python_version }}/bin/python bootstrap.py --setuptools-version=8.0.4 -c {{ plone_buildout_file }}
     creates={{ plone_instance_home }}/bin/buildout
     chdir={{ plone_instance_home }}
   sudo_user: "{{ plone_buildout_user }}"
 
 - name: Run buildout
   when: plone_autorun_buildout and (instance_status.changed or buildout_status.stat.exists == False)
-  command: bin/buildout
+  command: bin/buildout -c {{ plone_buildout_file }}
     chdir={{ plone_instance_home }}
   sudo_user: "{{ plone_buildout_user }}"
 


### PR DESCRIPTION
This is useful with a custom buildout that has various configurations for different deployment environments; e.g. development.cfg, staging.cfg, production.cfg.