### PR TITLE
updated supervisor to also control pound and varnish

### DIFF
--- a/templates/supervisor_task.j2
+++ b/templates/supervisor_task.j2
@@ -32,3 +32,21 @@ environment={% for name, value in task_env_vars.iteritems() %}{{ name }}="{{ val
 command=memmon -a {{ plone_client_max_memory }} -c -m root
 events=TICK_60
 {% endif %}
+
+[program:pound]
+command=/etc/init.d/pound restart
+directory=/etc/init.d
+autostart={{ plone_autostart }}
+autorestart={{ plone_autorestart }}
+user=root
+startsecs=0
+exitcodes=0
+
+[program:varnish]
+command=/etc/init.d/varnish restart
+directory=/etc/init.d
+autostart={{ plone_autostart }}
+autorestart={{ plone_autorestart }}
+user=root
+startsecs=0
+exitcodes=0


### PR DESCRIPTION
Adding these to the supervisor template so when you reload the zeos your charges are not caught up in a cache.

Should I also put these in { % if conditionals and have a setting set to zero in defaults/main.yml so it isn't enabled by default for users?

cc @smcmahon @jpgimenez 