### PR TITLE
Add 'plone_rsync_backup_options'

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,13 @@ How many generations of full backups do you wish to keep? Defaults to `2`.
 How many days of blob backups do you wish to keep? This is typically set to `keep_backups * days_between_packs` days. Default is `14`.
 
 
+#### plone_rsync_backup_options
+
+    plone_rsync_backup_options: --perms --chmod=ug+rx
+
+Rsync options set within the backup scripts (see [collective.recipe.backup](https://pypi.python.org/pypi/collective.recipe.backup#supported-options)). This can be used (for example) to change permissions on backups so they can be downloaded more easily. Defaults to empty.
+
+
 ### Supervisor Control
 
 #### plone_use_supervisor

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -86,6 +86,7 @@ plone_backup_at:
 plone_keep_backups: 3
 
 plone_keep_blob_days: 21
+plone_rsync_backup_options:
 
 plone_create_site: yes
 plone_site_id: Plone
@@ -167,6 +168,7 @@ instance_config:
   plone_backup_at: "{{ plone_config.plone_backup_at|default(plone_backup_at) }}"
   plone_keep_backups: "{{ plone_config.plone_keep_backups|default(plone_keep_backups) }}"
   plone_keep_blob_days: "{{ plone_config.plone_keep_blob_days|default(plone_keep_blob_days) }}"
+  plone_rsync_backup_options: "{{ plone_config.plone_rsync_backup_options|default(plone_rsync_backup_options) }}"
   plone_create_site: "{{ plone_config.plone_create_site|default(plone_create_site) }}"
   plone_site_id: "{{ plone_config.plone_site_id|default(plone_site_id) }}"
   plone_default_language: "{{ plone_config.plone_default_language|default(plone_default_language) }}"
@@ -184,5 +186,3 @@ instance_config:
   plone_extra_find_links: "{{ plone_config.plone_extra_find_links|default(plone_extra_find_links) }}"
   plone_always_run_buildout: "{{ plone_config.plone_always_run_buildout|default(plone_always_run_buildout) }}"
   plone_restart_after_buildout: "{{ plone_config.plone_restart_after_buildout|default(plone_restart_after_buildout) }}"
-
-

--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -185,6 +185,7 @@ datafs = ${buildout:var-dir}/filestorage/Data.fs
 blob-storage = ${buildout:var-dir}/blobstorage
 keep = {{ instance_config.plone_keep_backups }}
 keep_blob_days = {{ instance_config.plone_keep_blob_days }}
+rsync_options = {{ instance_config.plone_rsync_backup_options }}
 
 
 [setpermissions]


### PR DESCRIPTION
Should give the power to resolve #47  (*replacing* the less flexible solution in #66)  

I'm satisfied that this DOES put the options in the backup script.
That being said finding the right options to give permission on copying the backup files is ongoing and tricky (though not required here)