### PR TITLE
Rework quoting fix in db3c20a

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -351,7 +351,7 @@
   when: plone_pack_at
   cron:
     name="{{ instance_config.plone_instance_name }} Plone packing"
-    job='cd {{ plone_instance_home }} && bin/zeopack && echo "zeopack success for {{ instance_config.plone_instance_name }}"'
+    job='cd {{ plone_instance_home }} && bin/zeopack && echo "zeopack""_success for {{ instance_config.plone_instance_name }}"'
     user={{ instance_config.plone_daemon_user }}
     minute={{ item.minute }}
     hour={{ item.hour }}
@@ -363,7 +363,7 @@
   when: plone_backup_at
   cron:
     name="{{ instance_config.plone_instance_name }} Plone backup"
-    job='cd {{ plone_instance_home }} && bin/backup && echo "backup success for {{ instance_config.plone_instance_name }}"'
+    job='cd {{ plone_instance_home }} && bin/backup && echo "backup""_success for {{ instance_config.plone_instance_name }}"'
     user={{ instance_config.plone_daemon_user }}
     minute={{ item.minute }}
     hour={{ item.hour }}


### PR DESCRIPTION
Email client search filters are pretty basic - so we need to help them by breaking making the 'search target' a whole word: 'backup_success' but making sure it *doesn't* appear in the command line (which becomes the email subject)