### PR TITLE
Fix pins related to Plone Hotfix 20151006 

### DIFF
--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -238,10 +238,10 @@ plone.recipe.precompiler = 0.6
 {% if instance_config.plone_version < '5.0' %}
 setuptools = 7.0
 {% if instance_config.plone_version < '4.3.8' %}
-plone.csrffixes = 1.0.6
-plone.protect = 3.0.14
+plone4.csrffixes = 1.0.8
+plone.protect = 3.0.17
 plone.keyring = 3.0.1
-plone.locking = 2.0.8
+plone.locking = 2.0.9
 {% endif %}
 {% endif %}
 {% if instance_config.plone_version >= '5.0' %}


### PR DESCRIPTION
In particular `plone.csrffixes` needs to be `plone4.csrffixes`

See https://plone.org/products/plone-hotfix/releases/20151006 for current pins