### PR TITLE
Drop shallow clone

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -3,6 +3,9 @@
 - Add support for Xenial Xerus (Ubuntu 16.04).
   [smcmahon]
 
+- Drop shallow clone for Instance directory
+  [gomez]
+
 1.2.8 2016-04-25
 
 - Include Products.PloneHotfix20160419.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -144,7 +144,6 @@
     force=no
     dest={{ plone_instance_home }}
     version={{ instance_config.plone_buildout_git_version | default('HEAD') }}
-    depth=1
     accept_hostkey=yes
   become_user: "{{ instance_config.plone_buildout_user }}"
 


### PR DESCRIPTION
Drops the depth=1 as full clones are better for test installs 
Fixes #77 