### PR TITLE
Add var plone_buildout_cfg, to set the name the generated buildout file

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -46,6 +46,11 @@
 - Update source for wv for CentOS7.
   [smcmahon]
 
+- Add plone_buildout_cfg variable to generate buildoutfiles other than
+  buildout.cfg on the server. Alos change the default to live.cfg,
+  to avoid conflicts with local buildout.cfg files.
+  [MrTango]
+
 1.2.15 2017-02-01
 
 - Redirect stdout and stderr for buildout into a log file.

--- a/README.md
+++ b/README.md
@@ -309,6 +309,12 @@ Do you wish to automatically run buildout if any of the Plone settings change? D
 
 Do you wish to run buildout even if the buildout has not changed? Mainly useful in CI situations.
 
+### plone_buildout_cfg
+
+    plone_buildout_cfg: live.cfg
+
+This avoits conflicts with local buildout.cfg for development and the generated file on the server used for production/staging. Default to `live.cfg`.
+
 
 ### plone_buildout_cache_url
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,8 @@ plone_backup_path: no
 
 plone_instance_name: zeoserver
 
+plone_buildout_cfg: live.cfg
+
 plone_buildout_git_repo:
 
 plone_buildout_git_version: master

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -164,7 +164,7 @@
   when: not instance_config.plone_buildout_git_repo
   template:
     src=buildout.cfg.j2
-    dest={{ plone_instance_home }}/buildout.cfg
+    dest={{ plone_instance_home }}/{{ plone_buildout_cfg }}
     owner={{ instance_config.plone_buildout_user }}
     group={{ instance_config.plone_group }}
     backup=yes
@@ -229,7 +229,7 @@
 
 
 ###################################
-# Bootstrap and run buildout
+# Run buildout
 
 - name: Copy files from the buildout extra dir
   copy:
@@ -246,7 +246,7 @@
   when: instance_config.plone_always_run_buildout or
         instance_config.plone_autorun_buildout and
         (instance_status.changed or extra_dir_copy_result.changed or not buildout_status.stat.exists)
-  shell: "bin/buildout > buildout.log 2>&1"
+  shell: "bin/buildout -c {{ plone_buildout_cfg }} > buildout.log 2>&1"
   args:
     chdir: "{{ plone_instance_home }}"
   become_user: "{{ instance_config.plone_buildout_user }}"


### PR DESCRIPTION
This avoids conflicts with local buildout.cfg if one use a project repo for deployment and development. It also makes the deployment setup more flexible.