### PR TITLE
Fix

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -56,7 +56,7 @@
     mode=0755
 
 - name: Instance backup base directory
-  when: plone_backup_path
+  when: plone_backup_path is defined
   file:
     path={{ instance_config.plone_backup_path }}
     state=directory
@@ -160,7 +160,7 @@
     mode=02770
 
 - name: Instance backup directory
-  when: plone_backup_path
+  when: plone_backup_path is defined
   file:
     path="{{ plone_instance_backup_path }}"
     state=directory


### PR DESCRIPTION
In RHEL 7.3 the plone_backup_path generates a issue {"failed": true, "msg": "template error while templating string: unexpected '/'} when the playbook runs to deploy only a ZeoServer task. To fix this I just complete the sentence with "is defined" in "when" condition sentences.