### PR TITLE
Add option to use custom ansible buildout template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ local/
 *.retry
 *.log
 vbox_host.cfg
+/meta/.galaxy_install_info

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,9 @@
+1.2.18 unreleased
+
+- Add option to use custom ansible buildout template
+  [MrTango]
+
+
 1.2.18 2017-06-25
 
 - Custom backup paths were not working. Fix that and add some test coverage.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,17 @@ Your install's backup directory will be {{ plone_backup_path }}/{{ plone_instanc
 > If you use your own buildout, all Plone settings except `plone_client_count`, `plone_client_base_port`, and `plone_client_max_memory` are ignored.
 
 
+### plone_use_custom_buildout_template
+
+To use your own custom buildout template for this ansible role, set:
+
+    plone_use_custom_buildout_template: yes
+
+it defaults to `no` (uses built-in buildout template).
+
+Then provide a custom buildout template in your templates folder, which has the name: `buildout_custom.cfg.j2`
+
+
 ### plone_major_version
 
     plone_major_version: '5.0'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,6 +27,8 @@ plone_buildout_git_repo:
 
 plone_buildout_git_version: master
 
+plone_use_custom_buildout_template: no
+
 plone_initial_password:
 
 plone_install_zeoserver: yes
@@ -159,6 +161,7 @@ instance_config:
   plone_instance_name: "{{ plone_config.plone_instance_name|default(plone_instance_name) }}"
   plone_buildout_git_repo: "{{ plone_config.plone_buildout_git_repo|default(plone_buildout_git_repo) }}"
   plone_buildout_git_version: "{{ plone_config.plone_buildout_git_version|default(plone_buildout_git_version) }}"
+  plone_use_custom_buildout_template: "{{ plone_config.plone_use_custom_buildout_template|default(plone_use_custom_buildout_template) }}"
   plone_initial_password: "{{ plone_config.plone_initial_password|default(plone_initial_password) }}"
   plone_client_count: "{{ plone_config.plone_client_count|default(plone_client_count) }}"
   plone_zodb_cache_size: "{{ plone_config.plone_zodb_cache_size|default(plone_zodb_cache_size) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -160,8 +160,18 @@
     group={{ instance_config.plone_group }}
     mode=0700
 
+- name: Copy custom buildout template
+  when: instance_config.plone_use_custom_buildout_template
+  template:
+    src='buildout_custom.cfg.j2'
+    dest={{ plone_instance_home }}/buildout.cfg
+    owner={{ instance_config.plone_buildout_user }}
+    group={{ instance_config.plone_group }}
+    backup=yes
+  register: instance_status
+
 - name: Copy buildout template
-  when: not instance_config.plone_buildout_git_repo
+  when: not instance_config.plone_buildout_git_repo and not instance_config.plone_use_custom_buildout_template
   template:
     src=buildout.cfg.j2
     dest={{ plone_instance_home }}/buildout.cfg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -168,7 +168,7 @@
     owner={{ instance_config.plone_buildout_user }}
     group={{ instance_config.plone_group }}
     backup=yes
-  register: instance_status
+  register: custom_buildout_status
 
 - name: Copy buildout template
   when: not instance_config.plone_buildout_git_repo and not instance_config.plone_use_custom_buildout_template
@@ -234,7 +234,7 @@
   when: instance_config.plone_version >= '5.0' and bin_buildout.stat.exists == False
 
 - name: Check to see if buildout has already run
-  stat: path={{ plone_instance_home }}/bin/client_reserved
+  stat: path={{ plone_instance_home }}/bin/backup
   register: buildout_status
 
 
@@ -255,7 +255,9 @@
 - name: "Run buildout - output goes to {{ plone_instance_home }}/buildout.log"
   when: instance_config.plone_always_run_buildout or
         instance_config.plone_autorun_buildout and
-        (instance_status.changed or extra_dir_copy_result.changed or not buildout_status.stat.exists)
+        (instance_status.changed or custom_buildout_status.changed or
+        extra_dir_copy_result.changed or
+        not buildout_status.stat.exists)
   shell: "bin/buildout > buildout.log 2>&1"
   args:
     chdir: "{{ plone_instance_home }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -354,6 +354,11 @@
     path={{ plone_instance_home }}/scripts
     state=directory
 
+- name: Install site creation run script
+  template:
+    src=addPloneSite.py.j2
+    dest={{ plone_instance_home }}/scripts/addPloneSite.py
+    mode=0444
 
 ##################################
 # Add Plone site
@@ -362,12 +367,6 @@
 
     - name: Pause to let ZODB settle a bit
       pause: seconds=20
-
-    - name: Install site creation run script
-      template:
-        src=addPloneSite.py.j2
-        dest={{ plone_instance_home }}/scripts/addPloneSite.py
-        mode=0444
 
     - name: Create initial Plone site
       become_user: "{{ instance_config.plone_daemon_user }}"


### PR DESCRIPTION
To make the role more flexible, we allow a custom buildout.cfg for the role, which uses the same variables like the default one, but can be customized as needed. This is far more flexible and easier to understand than the git repo version of a external buildout config.