### PR TITLE
Change wv rpm URL for Centos7

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,6 +4,9 @@
   We need to know if that breaks.
   [smcmahon]
 
+- Change wv rpm URL for Centos7
+  [l00ptr]
+
 1.2.19 2017-10-29
 
 - Specify an index that will work with PyPI https.

--- a/tasks/RedHat.yml
+++ b/tasks/RedHat.yml
@@ -66,7 +66,7 @@
     - virtualenv
 
 - name: "CentOS 7: install wv from EPEL6"
-  yum: pkg=http://dl.fedoraproject.org/pub/epel/6/x86_64/wv-1.2.7-2.el6.x86_64.rpm state=present
+  yum: pkg=https://dl.fedoraproject.org/pub/epel/6/x86_64/Packages/w/wv-1.2.7-2.el6.x86_64.rpm state=present
   when: ansible_distribution == 'CentOS' and ansible_distribution_major_version == '7'
 
 - name: Supervisor config dir


### PR DESCRIPTION
The epel repository has been changed so the package is no longer
at the same place. We fixed the url to be able to download vw from
the new location.