### PR TITLE
bump superlance to the latest version 1.0 and support Python 3

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,3 +1,8 @@
+Unreleased
+
+- Bump superlance to v1.0 to support Python 3
+  [stevepiercy]
+
 1.3.7 2019-07-21
 
 - Make it possible to use Python 3 with Plone 5.2.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -299,7 +299,7 @@
 
 - name: Superlance installed
   when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0"
-  pip: name=superlance version=0.11 extra_args='--index-url=https://pypi.python.org/simple/'
+  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/'
 
 - name: Supervisor process control setup
   when: instance_config.plone_use_supervisor and ansible_os_family != 'Redhat'


### PR DESCRIPTION
This PR fixes an issue when I installed Plone 5.2 on Python 3.