### PR TITLE
Fix 122 superlance path py3

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -6,6 +6,10 @@
 - Earlier buildout fix in this release introduced a typo that broke buildout operation under some conditions. Fixed.
   [smcmahon]
 
+- If plone_python_version == '3', then append an argument to install
+  superlance that specifies the path to pip3.
+  [stevepiercy]
+
 - Bump superlance to v1.0 to support Python 3
   [stevepiercy]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -299,8 +299,12 @@
 # Supervisor setup
 
 - name: Superlance installed
-  when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0"
-  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/' {{ 'executable=' ~ virtualenv_path ~ 'pip3' if plone_python_version == '3' }}
+  when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0" and plone_python_version != '3'
+  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/'
+
+- name: Superlance installed
+  when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0" and plone_python_version == '3'
+  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/' executable={{ virtualenv_path }}pip3
 
 - name: Supervisor process control setup
   when: instance_config.plone_use_supervisor and ansible_os_family != 'Redhat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -300,7 +300,7 @@
 
 - name: Superlance installed
   when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0"
-  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/'
+  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/' {{ 'executable=' ~ virtualenv_path ~ 'pip3' if plone_python_version == '3' }}
 
 - name: Supervisor process control setup
   when: instance_config.plone_use_supervisor and ansible_os_family != 'Redhat'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -298,13 +298,16 @@
 ###################################
 # Supervisor setup
 
-- name: Superlance installed
-  when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0" and plone_python_version != '3'
-  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/'
+- block:
+    - name: Superlance installed
+      when: plone_python_major_version != '3'
+      pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/'
+    
+    - name: Superlance installed
+      when: plone_python_major_version == '3'
+      pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/' executable=pip3
+  when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0"
 
-- name: Superlance installed
-  when: instance_config.plone_use_supervisor and instance_config.plone_hot_monitor == 'superlance' and instance_config.plone_client_max_memory != "0" and plone_python_version == '3'
-  pip: name=superlance version=1.0 extra_args='--index-url=https://pypi.python.org/simple/' executable={{ virtualenv_path }}pip3
 
 - name: Supervisor process control setup
   when: instance_config.plone_use_supervisor and ansible_os_family != 'Redhat'

--- a/test.yml
+++ b/test.yml
@@ -122,7 +122,7 @@
     # make sure plone daemons have had time to come up
     - pause: minutes=1
 
-    - pip: name=httplib2 extra_args='--index-url=https://pypi.python.org/simple/' {{ 'executable=' ~ virtualenv_path ~ 'pip3' if plone_python_version == '3' }}
+    - pip: name=httplib2 extra_args='--index-url=https://pypi.python.org/simple/'
 
     - name: Check to see if Plone 5 is running
       uri:

--- a/test.yml
+++ b/test.yml
@@ -122,7 +122,7 @@
     # make sure plone daemons have had time to come up
     - pause: minutes=1
 
-    - pip: name=httplib2 extra_args='--index-url=https://pypi.python.org/simple/'
+    - pip: name=httplib2 extra_args='--index-url=https://pypi.python.org/simple/' {{ 'executable=' ~ virtualenv_path ~ 'pip3' if plone_python_version == '3' }}
 
     - name: Check to see if Plone 5 is running
       uri:

--- a/tests/python3_superlance.yml
+++ b/tests/python3_superlance.yml
@@ -1,0 +1,41 @@
+---
+
+# Test that superlance is being used with Python 3 when appropriate
+
+- hosts: all
+  become: yes
+  gather_facts: yes
+
+
+  vars:
+
+    plone_initial_password: admin
+    plone_version: 5.2.0
+    plone_python_version: "3.6"
+    plone_hot_monitor: superlance
+    plone_client_max_memory: 8500MB
+    plone_client_tcpcheck: no
+
+
+  roles:
+
+    - role: ansible.plone_server
+
+  tasks:
+
+    # make sure plone daemons have had time to come up
+    - pause: minutes=1
+
+    - pip: name=httplib2 extra_args='--index-url=https://pypi.python.org/simple/'
+
+    - name: Check to see if Zope is running
+      uri:
+        url: http://127.0.0.1:8081/
+        method: GET
+        status_code: 200
+
+    - name: Make sure memmon is using python3
+      shell: 'head --lines=1 /usr/local/bin/memmon | egrep "^#!.+/python3$"'
+
+# we also need a test to make sure it actually runs
+


### PR DESCRIPTION
This PR addresses https://github.com/plone/ansible-playbook/issues/122

If `plone_python_version` == '3', then append an argument to install superlance that specifies the path to pip3.