### PR TITLE
Bump PloneHotfix20200121 to v1.1

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.3.8 (unreleased)
 
+- Bump PloneHotfix20200121 to v1.1.
+  [stevepiercy]
+
 - Add PloneHotfix20200121. Normalize and sort hotfixes across eggs and
   versions sections.
   [stevepiercy]

--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -337,7 +337,7 @@ Products.PloneHotfix20170117 = 1.0
 Products.PloneHotfix20171128 = 1.0
 {% endif %}
 {% if instance_config.plone_version is version('4.3.19', '<=') %}
-Products.PloneHotfix20200121 = 1.0
+Products.PloneHotfix20200121 = 1.1
 {% endif %}
 {% endif %}
 {% if instance_config.plone_version is version('5.0', '>=') and instance_config.plone_version is version('5.1', '<') %}
@@ -353,17 +353,17 @@ Products.PloneHotfix20170117 = 1.0
 Products.PloneHotfix20171128 = 1.0
 {% endif %}
 {% if instance_config.plone_version is version('5.0.10', '<=') %}
-Products.PloneHotfix20200121 = 1.0
+Products.PloneHotfix20200121 = 1.1
 {% endif %}
 {% endif %}
 {% if instance_config.plone_version is version('5.1', '>=') and instance_config.plone_version is version('5.2', '<') %}
 {% if instance_config.plone_version is version('5.1.6', '<=') %}
-Products.PloneHotfix20200121 = 1.0
+Products.PloneHotfix20200121 = 1.1
 {% endif %}
 {% endif %}
 {% if instance_config.plone_version is version('5.2', '>=') %}
 {% if instance_config.plone_version is version('5.2.1', '<=') %}
-Products.PloneHotfix20200121 = 1.0
+Products.PloneHotfix20200121 = 1.1
 {% endif %}
 {% endif %}
 {% if instance_config.plone_additional_versions %}


### PR DESCRIPTION
See:
- https://plone.org/security/announcements/new-waitress-version-and-updated-20200121-hotfix
- https://plone.org/security/hotfix/20200121

Note that the version number shown in the instructions was not updated from 1.0 to 1.1 in all instances.

I could not find `waitress` anywhere in this repo or the ansible_playbook. I don't know how to force it to install v1.4.3. It appears that v1.3.0 is currently installed.