### PR TITLE
Don't try to restart memmon unless we're using superlance.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.3.9 unreleased
 
+- Don't try to restart memmon unless it's actually in use.
+  [smcmahon]
+
 - When copying buildout extra directory, preserve file modes.
   [smcmahon]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -344,6 +344,7 @@
 # Stopping, removing the part and updating does the trick.
 - name: Supervisor task list is updated and we have a memmon
   when: instance_config.plone_use_supervisor and
+        instance_config.plone_hot_monitor == 'superlance' and
         instance_config.plone_client_max_memory != "0" and
         supervisor_task_conf_debian is changed or supervisor_task_conf_redhat is changed
   shell: 'supervisorctl stop {{ supervisor_instance_discriminator }}memmon; supervisorctl remove {{ supervisor_instance_discriminator }}memmon'


### PR DESCRIPTION
Server build could fail unnecessarily trying to restart memmon when superlance wasn't in use.