### PR TITLE
Limit the chmod in setpermissions to files owned by plone_buildout

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.3.9 unreleased
 
+- Limit setpermissions to files owned by plone_buildout.
+  [djowett]
+
 - Show buildout.log in the Ansible output when buildout errors.
   [djowett]
 

--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.3.9 unreleased
 
+- Show buildout.log in the Ansible output when buildout errors.
+  [djowett]
+
 - Catch cases where supervisor needs an update after a config change.
   [smcmahon]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -279,16 +279,25 @@
   register: extra_dir_copy_result
   when: instance_config.plone_buildout_extra_dir
 
-- name: "Run buildout - output goes to {{ plone_instance_home }}/buildout.log"
+- block:
+  - name: "Run buildout - output goes to {{ plone_instance_home }}/buildout.log"
+    shell: "bin/buildout -c {{ instance_config.plone_buildout_cfg }} > buildout.log 2>&1"
+    args:
+      chdir: "{{ plone_instance_home }}"
+    become_user: "{{ instance_config.plone_buildout_user }}"
+    register: ran_buildout
   when: instance_config.plone_always_run_buildout or
         instance_config.plone_autorun_buildout and
         (instance_status.changed or requirements_status.changed or extra_dir_copy_result.changed or not
         buildout_status.stat.exists)
-  shell: "bin/buildout -c {{ instance_config.plone_buildout_cfg }} > buildout.log 2>&1"
-  args:
-    chdir: "{{ plone_instance_home }}"
-  become_user: "{{ instance_config.plone_buildout_user }}"
-  register: ran_buildout
+  rescue:
+    - name: Capture buildout error
+      shell: "cat {{ plone_instance_home }}/buildout.log"
+      register: buildout_error
+    - name: Show buildout error
+      debug: var=buildout_error.stdout_lines
+    - name: Buildout failed - stopping
+      command: /bin/false
 
 - name: Everything in buildout cache is group-readable
   file:

--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -288,7 +288,8 @@ command =
     echo ${backup:location} > /dev/null
     chmod 600 .installed.cfg
     # Make sure anything we've created in var is r/w by our group, but no-one else
-    chmod -R ug+rwX,o-rwx ${buildout:var-dir}
+    # use find as `chmod -R <var-dir>` will fail when plone_buildout doesn't own <var-dir>; max-depth 1 keeps it fast
+    find  ${buildout:var-dir} -maxdepth 1 -exec chmod -R ug+rwX,o-rwx {} \;
     chmod -R ug+rwX,o-rwx ${buildout:backups-dir}
     chmod 754 ${buildout:directory}/bin/*
 update-command = ${:command}

--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -288,10 +288,9 @@ command =
     echo ${backup:location} > /dev/null
     chmod 600 .installed.cfg
     # Make sure anything we've created in var is r/w by our group, but no-one else
-    # use find as `chmod -R <var-dir>` will fail when plone_buildout doesn't own <var-dir>; max-depth 1 keeps it fast
-    find  ${buildout:var-dir} -maxdepth 1 -exec chmod -R ug+rwX,o-rwx {} \;
-    chmod -R ug+rwX,o-rwx ${buildout:backups-dir}
-    chmod 754 ${buildout:directory}/bin/*
+    find  ${buildout:var-dir} -user {{ instance_config.plone_buildout_user }} -exec chmod -v ug+rwX,o-rwx {} \;
+    find  ${buildout:backups-dir} -user {{ instance_config.plone_buildout_user }} -exec chmod -v ug+rwX,o-rwx {} \;
+    chmod -v 754 ${buildout:directory}/bin/*
 update-command = ${:command}
 
 


### PR DESCRIPTION
    plone_buildout won't have permission to chmod anything else, so this
    stops a load of useless error messages

Helps with #82, though may not be a full fix.