### PR TITLE
Show buildout errors

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,5 +1,8 @@
 1.3.9 unreleased
 
+- Show buildout.log in the Ansible output when buildout errors.
+  [djowett]
+
 - Catch cases where supervisor needs an update after a config change.
   [smcmahon]
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -279,16 +279,25 @@
   register: extra_dir_copy_result
   when: instance_config.plone_buildout_extra_dir
 
-- name: "Run buildout - output goes to {{ plone_instance_home }}/buildout.log"
+- block:
+  - name: "Run buildout - output goes to {{ plone_instance_home }}/buildout.log"
+    shell: "bin/buildout -c {{ instance_config.plone_buildout_cfg }} > buildout.log 2>&1"
+    args:
+      chdir: "{{ plone_instance_home }}"
+    become_user: "{{ instance_config.plone_buildout_user }}"
+    register: ran_buildout
   when: instance_config.plone_always_run_buildout or
         instance_config.plone_autorun_buildout and
         (instance_status.changed or requirements_status.changed or extra_dir_copy_result.changed or not
         buildout_status.stat.exists)
-  shell: "bin/buildout -c {{ instance_config.plone_buildout_cfg }} > buildout.log 2>&1"
-  args:
-    chdir: "{{ plone_instance_home }}"
-  become_user: "{{ instance_config.plone_buildout_user }}"
-  register: ran_buildout
+  rescue:
+    - name: Capture buildout error
+      shell: "cat {{ plone_instance_home }}/buildout.log"
+      register: buildout_error
+    - name: Show buildout error
+      debug: var=buildout_error.stdout_lines
+    - name: Buildout failed - stopping
+      command: /bin/false
 
 - name: Everything in buildout cache is group-readable
   file:

--- a/templates/buildout.cfg.j2
+++ b/templates/buildout.cfg.j2
@@ -288,7 +288,8 @@ command =
     echo ${backup:location} > /dev/null
     chmod 600 .installed.cfg
     # Make sure anything we've created in var is r/w by our group, but no-one else
-    chmod -R ug+rwX,o-rwx ${buildout:var-dir}
+    # use find as `chmod -R <var-dir>` will fail when plone_buildout doesn't own <var-dir>; max-depth 1 keeps it fast
+    find  ${buildout:var-dir} -maxdepth 1 -exec chmod -R ug+rwX,o-rwx {} \;
     chmod -R ug+rwX,o-rwx ${buildout:backups-dir}
     chmod 754 ${buildout:directory}/bin/*
 update-command = ${:command}


### PR DESCRIPTION
It's nice to get buildout errors without having to sign in to the server - this change does that. For example:

```
TASK [plone.plone_server : Show buildout error] ********************************
task path: /home/daniel/ansible-playbook/roles/plone.plone_server/tasks/main.yml:290
ok: [hv-bionic] => {
    "buildout_error.stdout_lines": [
        "Uninstalling client_reserved.",
        "Uninstalling client1.",
        "Unused options for buildout: 'buildout-user' 'proj-environment-vars'.",
        "Updating zeoserver.",
        "Installing client1.",
        "While:",
        "  Installing client1.",
        "",
        "An internal error occurred due to a bug in either zc.buildout or in a",
        "recipe being used:",
        "Traceback (most recent call last):",
        "  File \"/usr/local/plone-4.3/python2.7/local/lib/python2.7/site-packages/zc/buildout/buildout.py\", line 2174, in main",
        "    getattr(buildout, command)(args)",
        "  File \"/usr/local/plone-4.3/python2.7/local/lib/python2.7/site-packages/zc/buildout/buildout.py\", line 817, in install",
        "    installed_files = self[part]._call(recipe.install)",
        "  File \"/usr/local/plone-4.3/python2.7/local/lib/python2.7/site-packages/zc/buildout/buildout.py\", line 1603, in _call",
        "    return f()",
        "  File \"/usr/local/plone-4.3/buildout-cache/eggs/plone.recipe.zope2instance-4.2.18-py2.7.egg/plone/recipe/zope2instance/__init__.py\", line 95, in install",
        "    major, minor = parsed[0:2]",
        "TypeError: 'Version' object has no attribute '__getitem__'"
    ]
}

```
